### PR TITLE
Turn `:core`'s `Authorizer` into a property of `Authenticator`

### DIFF
--- a/app/src/main/java/com/jeanbarrossilva/mastodonte/app/MastodonteModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/mastodonte/app/MastodonteModule.kt
@@ -2,12 +2,10 @@ package com.jeanbarrossilva.mastodonte.app
 
 import com.jeanbarrossilva.mastodonte.core.auth.AuthenticationLock
 import com.jeanbarrossilva.mastodonte.core.auth.Authenticator
-import com.jeanbarrossilva.mastodonte.core.auth.Authorizer
 import com.jeanbarrossilva.mastodonte.core.auth.actor.ActorProvider
 import com.jeanbarrossilva.mastodonte.core.feed.FeedProvider
 import com.jeanbarrossilva.mastodonte.core.profile.ProfileProvider
 import com.jeanbarrossilva.mastodonte.core.sample.auth.SampleAuthenticator
-import com.jeanbarrossilva.mastodonte.core.sample.auth.SampleAuthorizer
 import com.jeanbarrossilva.mastodonte.core.sample.feed.SampleFeedProvider
 import com.jeanbarrossilva.mastodonte.core.sample.profile.SampleProfileProvider
 import com.jeanbarrossilva.mastodonte.core.sample.toot.SampleTootProvider
@@ -24,11 +22,8 @@ internal fun MastodonteModule(
 ): Module {
     return module {
         single<ActorProvider> { SharedPreferencesActorProvider(androidContext()) }
-        single<Authorizer> { SampleAuthorizer }
         single<Authenticator> { SampleAuthenticator(actorProvider = get()) }
-        single {
-            AuthenticationLock(authorizer = get(), authenticator = get(), actorProvider = get())
-        }
+        single { AuthenticationLock(authenticator = get(), actorProvider = get()) }
         single<FeedProvider> { SampleFeedProvider }
         single<ProfileProvider> { SampleProfileProvider }
         single<TootProvider> { SampleTootProvider }

--- a/core-test/src/main/java/com/jeanbarrossilva/mastodonte/core/test/TestAuthenticationLock.kt
+++ b/core-test/src/main/java/com/jeanbarrossilva/mastodonte/core/test/TestAuthenticationLock.kt
@@ -6,7 +6,6 @@ import com.jeanbarrossilva.mastodonte.core.auth.actor.Actor
 /**
  * [AuthenticationLock] with test-specific default structures.
  *
- * @param authorizer [TestAuthorizer] by which [authenticator]'s authentication will be authorized.
  * @param authenticator [TestAuthenticator] through which the [Actor] will be authenticated if it
  * isn't and [unlock][AuthenticationLock.unlock] is called.
  * @param actorProvider [TestActorProvider] whose provided [Actor] will be ensured to be either
@@ -14,9 +13,8 @@ import com.jeanbarrossilva.mastodonte.core.auth.actor.Actor
  **/
 @Suppress("FunctionName")
 fun TestAuthenticationLock(
-    authorizer: TestAuthorizer = TestAuthorizer(),
     actorProvider: TestActorProvider = TestActorProvider(),
-    authenticator: TestAuthenticator = TestAuthenticator(actorProvider)
+    authenticator: TestAuthenticator = TestAuthenticator(actorProvider = actorProvider)
 ): AuthenticationLock {
-    return AuthenticationLock(authorizer, authenticator, actorProvider)
+    return AuthenticationLock(authenticator, actorProvider)
 }

--- a/core-test/src/main/java/com/jeanbarrossilva/mastodonte/core/test/TestAuthenticator.kt
+++ b/core-test/src/main/java/com/jeanbarrossilva/mastodonte/core/test/TestAuthenticator.kt
@@ -6,11 +6,15 @@ import com.jeanbarrossilva.mastodonte.core.auth.actor.Actor
 /**
  * [Authenticator] that switches the [Actor] locally on authentication.
  *
+ * @param authorizer [TestAuthorizer] with which the user will be authorized.
+ * @param actorProvider [TestActorProvider] to which the [authenticated][Actor.Authenticated]
+ * [Actor] will be sent to be remembered when authentication occurs.
  * @param onOnAuthenticate Operation to be performed when [onAuthenticate] is called.
  * @see currentActor
  * @see switchCurrentActor
  **/
 class TestAuthenticator(
+    override val authorizer: TestAuthorizer = TestAuthorizer(),
     override val actorProvider: TestActorProvider = TestActorProvider(),
     private val onOnAuthenticate: suspend (authorizationCode: String) -> Unit = { }
 ) : Authenticator() {

--- a/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/auth/SampleAuthenticator.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/auth/SampleAuthenticator.kt
@@ -1,11 +1,21 @@
 package com.jeanbarrossilva.mastodonte.core.sample.auth
 
 import com.jeanbarrossilva.mastodonte.core.auth.Authenticator
+import com.jeanbarrossilva.mastodonte.core.auth.Authorizer
 import com.jeanbarrossilva.mastodonte.core.auth.actor.Actor
 import com.jeanbarrossilva.mastodonte.core.auth.actor.ActorProvider
 
-/** [Authenticator] that provides a sample [Actor]. **/
-class SampleAuthenticator(override val actorProvider: ActorProvider) : Authenticator() {
+/**
+ * [Authenticator] that provides a sample [Actor].
+ *
+ * @param actorProvider [ActorProvider] to which the [authenticated][Actor.Authenticated] [Actor]
+ * will be sent to be remembered when authentication occurs.
+ **/
+class SampleAuthenticator(
+    override val actorProvider: ActorProvider
+) : Authenticator() {
+    override val authorizer: Authorizer = SampleAuthorizer
+
     override suspend fun onAuthenticate(authorizationCode: String): Actor {
         return Actor.Authenticated("sample-access-token")
     }

--- a/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/auth/SampleAuthorizer.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/auth/SampleAuthorizer.kt
@@ -3,7 +3,7 @@ package com.jeanbarrossilva.mastodonte.core.sample.auth
 import com.jeanbarrossilva.mastodonte.core.auth.Authorizer
 
 /** [Authorizer] that provides a sample authorization code. **/
-object SampleAuthorizer : Authorizer() {
+internal object SampleAuthorizer : Authorizer() {
     override suspend fun authorize(): String {
         return "sample-authorization-code"
     }

--- a/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLock.kt
+++ b/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLock.kt
@@ -9,14 +9,12 @@ import com.jeanbarrossilva.mastodonte.core.auth.actor.ActorProvider
  * - ...an [unauthenticated][Actor.Unauthenticated] [Actor], through [lock];
  * - ...an [authenticated][Actor.Authenticated] [Actor], through [unlock].
  *
- * @param authorizer [Authorizer] by which [authenticator]'s authentication will be authorized.
  * @param authenticator [Authenticator] through which the [Actor] will be authenticated if it isn't
  * and [unlock] is called.
  * @param actorProvider [ActorProvider] whose provided [Actor] will be ensured to be either
  * [unauthenticated][Actor.Unauthenticated] or [authenticated][Actor.Authenticated].
  **/
 class AuthenticationLock(
-    private val authorizer: Authorizer,
     private val authenticator: Authenticator,
     private val actorProvider: ActorProvider
 ) {
@@ -79,7 +77,7 @@ class AuthenticationLock(
      * [authenticated][Actor.Authenticated].
      **/
     private suspend fun authenticateAndNotify(listener: OnUnlockListener) {
-        val actor = authenticator.authenticate(authorizer)
+        val actor = authenticator.authenticate()
         if (actor is Actor.Authenticated) {
             listener.onUnlock(actor)
         }

--- a/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/Authenticator.kt
+++ b/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/Authenticator.kt
@@ -5,18 +5,17 @@ import com.jeanbarrossilva.mastodonte.core.auth.actor.ActorProvider
 
 /** Authenticates a user through [authenticate]. **/
 abstract class Authenticator {
+    /** [Authorizer] with which the user will be authorized. **/
+    protected abstract val authorizer: Authorizer
+
     /**
      * [ActorProvider] to which the [authenticated][Actor.Authenticated] [Actor] will be sent to be
      * remembered when authentication occurs.
      **/
     protected abstract val actorProvider: ActorProvider
 
-    /**
-     * Authorizes the user and then tries to authenticates them.
-     *
-     * @param authorizer [Authorizer] with which the user will be authorized.
-     **/
-    suspend fun authenticate(authorizer: Authorizer): Actor {
+    /** Authorizes the user with the [authorizer] and then tries to authenticates them. **/
+    suspend fun authenticate(): Actor {
         val authorizationCode = authorizer._authorize()
         val actor = onAuthenticate(authorizationCode)
         actorProvider._remember(actor)
@@ -24,7 +23,7 @@ abstract class Authenticator {
     }
 
     /**
-     * Authenticates the user.
+     * Tries to authenticate the user.
      *
      * @param authorizationCode Code that resulted from authorizing the user.
      **/

--- a/core/src/test/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLockTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLockTests.kt
@@ -25,10 +25,10 @@ internal class AuthenticationLockTests {
     fun `GIVEN an authenticated actor WHEN locking THEN the listener isn't notified`() {
         val authorizer = TestAuthorizer()
         val actorProvider = TestActorProvider()
-        val authenticator = TestAuthenticator(actorProvider)
+        val authenticator = TestAuthenticator(authorizer, actorProvider)
         var hasListenerBeenNotified = false
         runTest {
-            authenticator.authenticate(authorizer)
+            authenticator.authenticate()
             TestAuthenticationLock(authorizer, actorProvider, authenticator).lock {
                 hasListenerBeenNotified = true
             }

--- a/core/src/test/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLockTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLockTests.kt
@@ -3,7 +3,6 @@ package com.jeanbarrossilva.mastodonte.core.auth
 import com.jeanbarrossilva.mastodonte.core.test.TestActorProvider
 import com.jeanbarrossilva.mastodonte.core.test.TestAuthenticationLock
 import com.jeanbarrossilva.mastodonte.core.test.TestAuthenticator
-import com.jeanbarrossilva.mastodonte.core.test.TestAuthorizer
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -23,13 +22,12 @@ internal class AuthenticationLockTests {
 
     @Test
     fun `GIVEN an authenticated actor WHEN locking THEN the listener isn't notified`() {
-        val authorizer = TestAuthorizer()
         val actorProvider = TestActorProvider()
-        val authenticator = TestAuthenticator(authorizer, actorProvider)
+        val authenticator = TestAuthenticator(actorProvider = actorProvider)
         var hasListenerBeenNotified = false
         runTest {
             authenticator.authenticate()
-            TestAuthenticationLock(authorizer, actorProvider, authenticator).lock {
+            TestAuthenticationLock(actorProvider, authenticator).lock {
                 hasListenerBeenNotified = true
             }
         }

--- a/core/src/test/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticatorTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticatorTests.kt
@@ -14,7 +14,7 @@ internal class AuthenticatorTests {
     fun `GIVEN an authentication WHEN verifying if the actor is authorized THEN it is`() {
         var isAuthorized = false
         val authorizer = TestAuthorizer { isAuthorized = true }
-        runTest { TestAuthenticator().authenticate(authorizer) }
+        runTest { TestAuthenticator(authorizer).authenticate() }
         assertTrue(isAuthorized)
     }
 
@@ -23,7 +23,7 @@ internal class AuthenticatorTests {
         lateinit var providedAuthorizationCode: String
         val authorizer = TestAuthorizer()
         val authenticator = TestAuthenticator { providedAuthorizationCode = it }
-        runTest { authenticator.authenticate(authorizer) }
+        runTest { authenticator.authenticate() }
         assertEquals(TestAuthorizer.AUTHORIZATION_CODE, providedAuthorizationCode)
     }
 
@@ -32,7 +32,7 @@ internal class AuthenticatorTests {
         val authorizer = TestAuthorizer()
         val authenticator = TestAuthenticator()
         runTest {
-            assertIs<Actor.Authenticated>(authenticator.authenticate(authorizer))
+            assertIs<Actor.Authenticated>(authenticator.authenticate())
         }
     }
 }

--- a/core/src/test/java/com/jeanbarrossilva/mastodonte/core/auth/actor/ActorProviderTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/mastodonte/core/auth/actor/ActorProviderTests.kt
@@ -2,7 +2,6 @@ package com.jeanbarrossilva.mastodonte.core.auth.actor
 
 import com.jeanbarrossilva.mastodonte.core.test.TestActorProvider
 import com.jeanbarrossilva.mastodonte.core.test.TestAuthenticator
-import com.jeanbarrossilva.mastodonte.core.test.TestAuthorizer
 import kotlin.test.assertEquals
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -11,10 +10,9 @@ internal class ActorProviderTests {
     @Test
     fun `GIVEN a provider WHEN authenticating THEN it provides the resulting actor`() {
         val actorProvider = TestActorProvider()
-        val authorizer = TestAuthorizer()
-        val authenticator = TestAuthenticator(actorProvider)
+        val authenticator = TestAuthenticator(actorProvider = actorProvider)
         runTest {
-            val actor = authenticator.authenticate(authorizer)
+            val actor = authenticator.authenticate()
             assertEquals(actor, actorProvider.provide())
         }
     }

--- a/feature/auth/src/main/java/com/jeanbarrossilva/mastodonte/feature/auth/AuthActivity.kt
+++ b/feature/auth/src/main/java/com/jeanbarrossilva/mastodonte/feature/auth/AuthActivity.kt
@@ -5,15 +5,13 @@ import android.content.Intent
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import com.jeanbarrossilva.mastodonte.core.auth.Authenticator
-import com.jeanbarrossilva.mastodonte.core.auth.Authorizer
 import com.jeanbarrossilva.mastodonte.platform.ui.core.composable.ComposableActivity
 import org.koin.android.ext.android.inject
 
 class AuthActivity internal constructor() : ComposableActivity() {
-    private val authorizer by inject<Authorizer>()
     private val authenticator by inject<Authenticator>()
     private val viewModel by viewModels<AuthViewModel> {
-        AuthViewModel.createFactory(authorizer, authenticator, listener = ::finish)
+        AuthViewModel.createFactory(authenticator, listener = ::finish)
     }
 
     @Composable

--- a/feature/auth/src/main/java/com/jeanbarrossilva/mastodonte/feature/auth/AuthViewModel.kt
+++ b/feature/auth/src/main/java/com/jeanbarrossilva/mastodonte/feature/auth/AuthViewModel.kt
@@ -6,13 +6,11 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.jeanbarrossilva.mastodonte.core.auth.Authenticator
-import com.jeanbarrossilva.mastodonte.core.auth.Authorizer
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 internal class AuthViewModel private constructor(
-    private val authorizer: Authorizer,
     private val authenticator: Authenticator,
     private val listener: OnAuthenticationListener
 ) : ViewModel() {
@@ -32,20 +30,17 @@ internal class AuthViewModel private constructor(
 
     fun signIn() {
         viewModelScope.launch {
-            authenticator.authenticate(authorizer)
+            authenticator.authenticate()
             listener.onAuthentication()
         }
     }
 
     companion object {
-        fun createFactory(
-            authorizer: Authorizer,
-            authenticator: Authenticator,
-            listener: OnAuthenticationListener
-        ): ViewModelProvider.Factory {
+        fun createFactory(authenticator: Authenticator, listener: OnAuthenticationListener):
+            ViewModelProvider.Factory {
             return viewModelFactory {
                 initializer {
-                    AuthViewModel(authorizer, authenticator, listener)
+                    AuthViewModel(authenticator, listener)
                 }
             }
         }

--- a/feature/auth/src/test/java/com/jeanbarrossilva/mastodonte/feature/auth/test/AuthModule.kt
+++ b/feature/auth/src/test/java/com/jeanbarrossilva/mastodonte/feature/auth/test/AuthModule.kt
@@ -1,9 +1,7 @@
 package com.jeanbarrossilva.mastodonte.feature.auth.test
 
 import com.jeanbarrossilva.mastodonte.core.auth.Authenticator
-import com.jeanbarrossilva.mastodonte.core.auth.Authorizer
 import com.jeanbarrossilva.mastodonte.core.sample.auth.SampleAuthenticator
-import com.jeanbarrossilva.mastodonte.core.sample.auth.SampleAuthorizer
 import com.jeanbarrossilva.mastodonte.core.test.TestActorProvider
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -11,7 +9,8 @@ import org.koin.dsl.module
 @Suppress("TestFunctionName")
 internal fun AuthModule(): Module {
     return module {
-        single<Authorizer> { SampleAuthorizer }
-        single<Authenticator> { SampleAuthenticator(TestActorProvider()) }
+        single<Authenticator> {
+            SampleAuthenticator(TestActorProvider())
+        }
     }
 }


### PR DESCRIPTION
Adds [`Authenticator.authorizer`](https://github.com/jeanbarrossilva/Mastodonte/blob/36b2d2d575469756f11653f4262a1e693bb84ab5/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/Authenticator.kt#L9) instead of having to pass an [`Authorizer`](https://github.com/jeanbarrossilva/Mastodonte/blob/36b2d2d575469756f11653f4262a1e693bb84ab5/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/Authorizer.kt#L4) in each time authentication is performed.