### PR TITLE
Fix unresponsive feed toots

### DIFF
--- a/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/feed/SampleFeedProvider.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/feed/SampleFeedProvider.kt
@@ -4,16 +4,16 @@ import com.jeanbarrossilva.mastodonte.core.feed.FeedProvider
 import com.jeanbarrossilva.mastodonte.core.profile.Profile
 import com.jeanbarrossilva.mastodonte.core.sample.profile.SampleProfile
 import com.jeanbarrossilva.mastodonte.core.sample.profile.sample
-import com.jeanbarrossilva.mastodonte.core.sample.toot.samples
+import com.jeanbarrossilva.mastodonte.core.sample.toot.SampleTootProvider
 import com.jeanbarrossilva.mastodonte.core.toot.Toot
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 
 /** [FeedProvider] that provides a feed for a sample [Profile]. **/
 object SampleFeedProvider : FeedProvider() {
     /** [Flow] with the toots to be provided in the feed. **/
-    private val tootsFlow = flowOf(Toot.samples)
+    private val tootsFlow = SampleTootProvider.tootsFlow.asStateFlow()
 
     override suspend fun onProvide(userID: String, page: Int): Flow<List<Toot>> {
         return tootsFlow.map {

--- a/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/toot/SampleTootWriter.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/toot/SampleTootWriter.kt
@@ -5,7 +5,7 @@ import com.jeanbarrossilva.mastodonte.core.toot.Toot
 import kotlinx.coroutines.flow.update
 
 /** Performs [Toot]-related writing operations. **/
-internal object SampleTootWriter {
+object SampleTootWriter {
     /**
      * Defines whether the [Toot] identified as [id] is marked as favorite.
      *

--- a/feature/feed/build.gradle.kts
+++ b/feature/feed/build.gradle.kts
@@ -29,6 +29,13 @@ android {
         compose = true
     }
 
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+
     compileOptions {
         sourceCompatibility = Versions.java
         targetCompatibility = Versions.java
@@ -36,6 +43,7 @@ android {
 
     kotlinOptions {
         jvmTarget = Versions.java.toString()
+        freeCompilerArgs = listOf("-Xcontext-receivers")
     }
 
     composeOptions {
@@ -50,4 +58,9 @@ dependencies {
     implementation(project(":platform:ui"))
     implementation(Dependencies.KOIN_ANDROID)
     implementation(Dependencies.LOADABLE_LIST)
+
+    testImplementation(project(":platform:ui-test"))
+    testImplementation(Dependencies.COMPOSE_UI_TEST_JUNIT_4)
+    testImplementation(Dependencies.COMPOSE_UI_TEST_MANIFEST)
+    testImplementation(Dependencies.ROBOLECTRIC)
 }

--- a/feature/feed/src/main/java/com/jeanbarrossilva/mastodonte/feature/feed/Feed.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/mastodonte/feature/feed/Feed.kt
@@ -52,6 +52,42 @@ internal fun Feed(
 }
 
 @Composable
+internal fun Feed(
+    toots: List<Toot>,
+    onSearch: () -> Unit,
+    onFavorite: (tootID: String) -> Unit,
+    onReblog: (tootID: String) -> Unit,
+    onShare: (URL) -> Unit,
+    onTootClick: (tootID: String) -> Unit,
+    onNext: (index: Int) -> Unit,
+    onComposition: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Feed(
+        onSearch,
+        timelineContentPadding = MastodonteTheme.overlays.fab,
+        toots = {
+            items(toots) {
+                TootPreview(
+                    it.toTootPreview(),
+                    onFavorite = { onFavorite(it.id) },
+                    onReblog = { onReblog(it.id) },
+                    onShare = { onShare(it.url) },
+                    onClick = { onTootClick(it.id) }
+                )
+            }
+        },
+        onNext,
+        floatingActionButton = {
+            FloatingActionButton(onClick = onComposition) {
+                Icon(MastodonteTheme.Icons.Create, contentDescription = "Compose")
+            }
+        },
+        modifier
+    )
+}
+
+@Composable
 private fun Feed(
     tootsLoadable: ListLoadable<Toot>,
     onSearch: () -> Unit,
@@ -91,42 +127,6 @@ private fun Feed(onSearch: () -> Unit, modifier: Modifier = Modifier) {
         toots = LazyListScope::loadingTootPreviews,
         onNext = { },
         floatingActionButton = { },
-        modifier
-    )
-}
-
-@Composable
-private fun Feed(
-    toots: List<Toot>,
-    onSearch: () -> Unit,
-    onFavorite: (tootID: String) -> Unit,
-    onReblog: (tootID: String) -> Unit,
-    onShare: (URL) -> Unit,
-    onTootClick: (tootID: String) -> Unit,
-    onNext: (index: Int) -> Unit,
-    onComposition: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Feed(
-        onSearch,
-        timelineContentPadding = MastodonteTheme.overlays.fab,
-        toots = {
-            items(toots) {
-                TootPreview(
-                    it.toTootPreview(),
-                    onFavorite = { onFavorite(it.id) },
-                    onReblog = { onReblog(it.id) },
-                    onShare = { onShare(it.url) },
-                    onClick = { onTootClick(it.id) }
-                )
-            }
-        },
-        onNext,
-        floatingActionButton = {
-            FloatingActionButton(onClick = onComposition) {
-                Icon(MastodonteTheme.Icons.Create, contentDescription = "Compose")
-            }
-        },
         modifier
     )
 }

--- a/feature/feed/src/main/java/com/jeanbarrossilva/mastodonte/feature/feed/FeedFragment.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/mastodonte/feature/feed/FeedFragment.kt
@@ -34,7 +34,7 @@ class FeedFragment internal constructor() : ComposableFragment(), ContextProvide
     }
 
     companion object {
-        private const val USER_ID_KEY = "user-id"
+        internal const val USER_ID_KEY = "user-id"
 
         const val TAG = "feed-fragment"
     }

--- a/feature/feed/src/main/java/com/jeanbarrossilva/mastodonte/feature/feed/FeedViewModel.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/mastodonte/feature/feed/FeedViewModel.kt
@@ -1,6 +1,5 @@
 package com.jeanbarrossilva.mastodonte.feature.feed
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -36,14 +35,6 @@ internal class FeedViewModel(
     val tootsLoadableFlow = indexMutableFlow
         .flatMapConcat { getTootsAt(it) }
         .listLoadable(viewModelScope, SharingStarted.WhileSubscribed())
-
-    init {
-        viewModelScope.launch {
-            tootsLoadableFlow.collect {
-                Log.d("FeedViewModel", "tootsLoadableFlow: $it")
-            }
-        }
-    }
 
     fun favorite(tootID: String) {
         viewModelScope.launch {

--- a/feature/feed/src/test/java/com/jeanbarrossilva/mastodonte/feature/feed/FeedFragmentTests.kt
+++ b/feature/feed/src/test/java/com/jeanbarrossilva/mastodonte/feature/feed/FeedFragmentTests.kt
@@ -1,0 +1,48 @@
+package com.jeanbarrossilva.mastodonte.feature.feed
+
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.performClick
+import com.jeanbarrossilva.mastodonte.core.profile.Profile
+import com.jeanbarrossilva.mastodonte.core.sample.profile.sample
+import com.jeanbarrossilva.mastodonte.core.sample.toot.SampleTootWriter
+import com.jeanbarrossilva.mastodonte.feature.feed.test.FeedActivity
+import com.jeanbarrossilva.mastodonte.platform.ui.component.timeline.toot.TOOT_PREVIEW_FAVORITE_STAT_TAG
+import com.jeanbarrossilva.mastodonte.platform.ui.test.component.timeline.toot.onTootPreviews
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class FeedFragmentTests {
+    @get:Rule
+    val composeRule = createEmptyComposeRule()
+
+    @Test
+    fun `GIVEN a toot WHEN marking it as favorite THEN it's favorited`() {
+        runTest {
+            SampleTootWriter
+                .updateFavorite(Profile.sample.getToots(page = 0).first().first().id, false)
+        }
+        Robolectric
+            .buildActivity(FeedActivity::class.java, FeedActivity.getIntent(Profile.sample.id))
+            .setup()
+            .use {
+                composeRule
+                    .onTootPreviews()
+                    .onFirst()
+                    .onChildren()
+                    .filterToOne(hasTestTag(TOOT_PREVIEW_FAVORITE_STAT_TAG))
+                    .performClick()
+                    .assertIsSelected()
+            }
+    }
+}

--- a/feature/feed/src/test/java/com/jeanbarrossilva/mastodonte/feature/feed/FeedTests.kt
+++ b/feature/feed/src/test/java/com/jeanbarrossilva/mastodonte/feature/feed/FeedTests.kt
@@ -1,0 +1,50 @@
+package com.jeanbarrossilva.mastodonte.feature.feed
+
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.performClick
+import com.jeanbarrossilva.mastodonte.core.sample.toot.samples
+import com.jeanbarrossilva.mastodonte.core.toot.Toot
+import com.jeanbarrossilva.mastodonte.platform.theme.MastodonteTheme
+import com.jeanbarrossilva.mastodonte.platform.ui.component.timeline.toot.TOOT_PREVIEW_FAVORITE_STAT_TAG
+import com.jeanbarrossilva.mastodonte.platform.ui.test.component.timeline.toot.onTootPreviews
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class FeedTests {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `GIVEN a toot's favorite stat WHEN clicking it THEN the callback is called`() {
+        var hasCallbackBeenCalled = false
+        composeRule.setContent {
+            MastodonteTheme {
+                Feed(
+                    Toot.samples,
+                    onSearch = { },
+                    onFavorite = { hasCallbackBeenCalled = true },
+                    onReblog = { },
+                    onShare = { },
+                    onTootClick = { },
+                    onNext = { },
+                    onComposition = { }
+                )
+            }
+        }
+        composeRule
+            .onTootPreviews()
+            .onFirst()
+            .onChildren()
+            .filterToOne(hasTestTag(TOOT_PREVIEW_FAVORITE_STAT_TAG))
+            .performClick()
+        assertTrue(hasCallbackBeenCalled)
+    }
+}

--- a/feature/feed/src/test/java/com/jeanbarrossilva/mastodonte/feature/feed/test/FeedActivity.kt
+++ b/feature/feed/src/test/java/com/jeanbarrossilva/mastodonte/feature/feed/test/FeedActivity.kt
@@ -1,0 +1,42 @@
+package com.jeanbarrossilva.mastodonte.feature.feed.test
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.os.bundleOf
+import androidx.navigation.NavGraphBuilder
+import androidx.test.platform.app.InstrumentationRegistry
+import com.jeanbarrossilva.mastodonte.feature.feed.FeedFragment
+import com.jeanbarrossilva.mastodonte.platform.ui.test.core.SingleFragmentActivity
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+
+internal class FeedActivity : SingleFragmentActivity() {
+    override val route = "feed"
+
+    override fun NavGraphBuilder.add() {
+        fragment<FeedFragment>()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        inject()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        stopKoin()
+    }
+
+    private fun inject() {
+        val module = FeedModule()
+        startKoin { modules(module) }
+    }
+
+    companion object {
+        fun getIntent(userID: String): Intent {
+            val context = InstrumentationRegistry.getInstrumentation().context
+            val extras = bundleOf(FeedFragment.USER_ID_KEY to userID)
+            return Intent(context, FeedActivity::class.java).apply { putExtras(extras) }
+        }
+    }
+}

--- a/feature/feed/src/test/java/com/jeanbarrossilva/mastodonte/feature/feed/test/FeedModule.kt
+++ b/feature/feed/src/test/java/com/jeanbarrossilva/mastodonte/feature/feed/test/FeedModule.kt
@@ -1,0 +1,18 @@
+package com.jeanbarrossilva.mastodonte.feature.feed.test
+
+import com.jeanbarrossilva.mastodonte.core.feed.FeedProvider
+import com.jeanbarrossilva.mastodonte.core.sample.feed.SampleFeedProvider
+import com.jeanbarrossilva.mastodonte.core.sample.toot.SampleTootProvider
+import com.jeanbarrossilva.mastodonte.core.toot.TootProvider
+import com.jeanbarrossilva.mastodonte.feature.feed.FeedBoundary
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+@Suppress("TestFunctionName")
+internal fun FeedModule(): Module {
+    return module {
+        single<FeedProvider> { SampleFeedProvider }
+        single<TootProvider> { SampleTootProvider }
+        single<FeedBoundary> { TestFeedBoundary() }
+    }
+}

--- a/feature/feed/src/test/java/com/jeanbarrossilva/mastodonte/feature/feed/test/TestFeedBoundary.kt
+++ b/feature/feed/src/test/java/com/jeanbarrossilva/mastodonte/feature/feed/test/TestFeedBoundary.kt
@@ -1,0 +1,14 @@
+package com.jeanbarrossilva.mastodonte.feature.feed.test
+
+import com.jeanbarrossilva.mastodonte.feature.feed.FeedBoundary
+
+internal class TestFeedBoundary : FeedBoundary {
+    override fun navigateToSearch() {
+    }
+
+    override fun navigateToTootDetails(id: String) {
+    }
+
+    override fun navigateToComposer() {
+    }
+}


### PR DESCRIPTION
Fixes a bug in which the feed's toots' state changes weren't observed and shown to the user; so, when favoriting or reblogging, the actual operations would be performed, but the toot wouldn't be shown as favorited or reblogged in the feed.

This happened because [`SampleFeedProvider`](https://github.com/jeanbarrossilva/Mastodonte/blob/3f1b9e3adaa22ed995522c3a5d85c62d825eef2e/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/feed/SampleFeedProvider.kt) provided a `flowOf(Toot.samples)` instead of using the one from [`SampleTootProvider`](https://github.com/jeanbarrossilva/Mastodonte/blob/3f1b9e3adaa22ed995522c3a5d85c62d825eef2e/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/toot/SampleTootProvider.kt).