### PR TITLE
Authenticate with an `Account`

### DIFF
--- a/core-test/src/main/java/com/jeanbarrossilva/mastodonte/core/test/TestAuthenticator.kt
+++ b/core-test/src/main/java/com/jeanbarrossilva/mastodonte/core/test/TestAuthenticator.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.mastodonte.core.test
 
+import com.jeanbarrossilva.mastodonte.core.account.Account
 import com.jeanbarrossilva.mastodonte.core.auth.Authenticator
 import com.jeanbarrossilva.mastodonte.core.auth.actor.Actor
 
@@ -31,7 +32,7 @@ class TestAuthenticator(
      **/
     private val authenticatedActor = Actor.Authenticated("access-token")
 
-    override suspend fun onAuthenticate(authorizationCode: String): Actor {
+    override suspend fun onAuthenticate(account: Account, authorizationCode: String): Actor {
         onOnAuthenticate(authorizationCode)
         switchCurrentActor()
         return currentActor

--- a/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/auth/SampleAuthenticator.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/mastodonte/core/sample/auth/SampleAuthenticator.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.mastodonte.core.sample.auth
 
+import com.jeanbarrossilva.mastodonte.core.account.Account
 import com.jeanbarrossilva.mastodonte.core.auth.Authenticator
 import com.jeanbarrossilva.mastodonte.core.auth.Authorizer
 import com.jeanbarrossilva.mastodonte.core.auth.actor.Actor
@@ -16,7 +17,7 @@ class SampleAuthenticator(
 ) : Authenticator() {
     override val authorizer: Authorizer = SampleAuthorizer
 
-    override suspend fun onAuthenticate(authorizationCode: String): Actor {
+    override suspend fun onAuthenticate(account: Account, authorizationCode: String): Actor {
         return Actor.Authenticated("sample-access-token")
     }
 }

--- a/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/Authenticator.kt
+++ b/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/Authenticator.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.mastodonte.core.auth
 
+import com.jeanbarrossilva.mastodonte.core.account.Account
 import com.jeanbarrossilva.mastodonte.core.auth.actor.Actor
 import com.jeanbarrossilva.mastodonte.core.auth.actor.ActorProvider
 
@@ -14,18 +15,24 @@ abstract class Authenticator {
      **/
     protected abstract val actorProvider: ActorProvider
 
-    /** Authorizes the user with the [authorizer] and then tries to authenticates them. **/
-    suspend fun authenticate(): Actor {
+    /**
+     * Authorizes with the [authorizer] and then tries to authenticates the [account].
+     *
+     * @param account [Account] to authenticate.
+     **/
+    suspend fun authenticate(account: Account): Actor {
         val authorizationCode = authorizer._authorize()
-        val actor = onAuthenticate(authorizationCode)
+        val actor = onAuthenticate(account, authorizationCode)
         actorProvider._remember(actor)
         return actor
     }
 
     /**
-     * Tries to authenticate the user.
+     * Tries to authenticate the [account].
      *
+     * @param account [Account] to authenticate.
      * @param authorizationCode Code that resulted from authorizing the user.
      **/
-    protected abstract suspend fun onAuthenticate(authorizationCode: String): Actor
+    protected abstract suspend fun onAuthenticate(account: Account, authorizationCode: String):
+        Actor
 }


### PR DESCRIPTION
Adds an `account` param to [`Authenticator.authenticate`](https://github.com/jeanbarrossilva/Mastodonte/blob/58cc8a10d5e95aff4c3d43fe9842ce4ec5a93d5a/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/Authenticator.kt#L23).