### PR TITLE
Add `Follow.Companion.of` `String` parser function

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,14 @@ permissions:
   contents: read
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'temurin'
+          distribution: 'corretto'
       - name: Build with Gradle
         env:
           GITHUB_USERNAME: ${{ github.actor }}

--- a/core/src/main/java/com/jeanbarrossilva/mastodonte/core/profile/follow/Follow.kt
+++ b/core/src/main/java/com/jeanbarrossilva/mastodonte/core/profile/follow/Follow.kt
@@ -131,6 +131,51 @@ abstract class Follow private constructor() : Serializable {
 
     companion object {
         /**
+         * [IllegalArgumentException] thrown if a blank [String] is given when parsing it into a
+         * [Follow].
+         *
+         * @see of
+         **/
+        class BlankStringException internal constructor() :
+            IllegalArgumentException("Cannot parse a blank String.")
+
+        /**
+         * [IllegalArgumentException] thrown if the given [String] is not a valid [Follow]
+         * representation.
+         *
+         * @param string [Follow] representation that's invalid.
+         **/
+        class InvalidFollowString internal constructor(string: String) : IllegalArgumentException(
+            "\"$string\" does not match any of the available Follow String representations."
+        )
+
+        /**
+         * Parses the [string] into a [Follow].
+         *
+         * [string] must be the result of calling [toString] on one of the existing [Follow]s
+         * (e. g., `Follow.of("${Follow.Public.unfollowed()}")` returns [Public.unfollowed]). Any
+         * leading or trailing whitespace it may contain will be ignored.
+         *
+         * @param string [String] to be parsed into a [Follow].
+         * @return [Follow] whose result of [toString] equals to the [string] (minus surrounding
+         * whitespaces).
+         * @throws BlankStringException If the [string] is blank.
+         * @throws InvalidFollowString If the [string] is not a valid [Follow] representation.
+         **/
+        fun of(string: String): Follow {
+            val formattedString = string.trim()
+            formattedString.ifBlank { throw BlankStringException() }
+            return when (formattedString) {
+                Public.unfollowed().toString() -> Public.unfollowed()
+                Public.following().toString() -> Public.following()
+                Private.unfollowed().toString() -> Private.unfollowed()
+                Private.requested().toString() -> Private.requested()
+                Private.following().toString() -> Private.following()
+                else -> throw InvalidFollowString(formattedString)
+            }
+        }
+
+        /**
          * Requires both statuses to have the same visibility: either [public][Follow.Public] or
          * [private][Follow.Private].
          *

--- a/core/src/test/java/com/jeanbarrossilva/mastodonte/core/profile/follow/FollowTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/mastodonte/core/profile/follow/FollowTests.kt
@@ -6,6 +6,45 @@ import kotlin.test.assertFailsWith
 
 internal class FollowTests {
     @Test
+    fun `GIVEN a blank string WHEN parsing it into a follow status THEN it throws`() {
+        assertFailsWith<Follow.Companion.BlankStringException> {
+            Follow.of(" ")
+        }
+    }
+
+    @Test
+    fun `GIVEN an invalid string WHEN parsing it into a follow status THEN it throws`() {
+        assertFailsWith<Follow.Companion.InvalidFollowString> {
+            Follow.of("🥸")
+        }
+    }
+
+    @Test
+    fun `GIVEN a public unfollowed status string WHEN parsing it THEN it returns the status`() {
+        assertEquals(Follow.Public.unfollowed(), Follow.of("${Follow.Public.unfollowed()}"))
+    }
+
+    @Test
+    fun `GIVEN a public following status string WHEN parsing it THEN it returns the status`() {
+        assertEquals(Follow.Public.following(), Follow.of("${Follow.Public.following()}"))
+    }
+
+    @Test
+    fun `GIVEN a private unfollowed status string WHEN parsing it THEN it returns the status`() {
+        assertEquals(Follow.Private.unfollowed(), Follow.of("${Follow.Private.unfollowed()}"))
+    }
+
+    @Test
+    fun `GIVEN a private requested status string WHEN parsing it THEN it returns the status`() {
+        assertEquals(Follow.Private.requested(), Follow.of("${Follow.Private.requested()}"))
+    }
+
+    @Test
+    fun `GIVEN a private following status string WHEN parsing it THEN it returns the status`() {
+        assertEquals(Follow.Private.following(), Follow.of("${Follow.Private.following()}"))
+    }
+
+    @Test
     fun `GIVEN a public unfollowed status WHEN toggling it THEN it's followed`() {
         assertEquals(Follow.Public.following(), Follow.Public.unfollowed().toggled())
     }


### PR DESCRIPTION
Adds a function for parsing a [`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string) into a [`Follow`](https://github.com/jeanbarrossilva/Mastodonte/blob/96c0a18e60dea602c4dc1f59f53489513a45a623/core/src/main/java/com/jeanbarrossilva/mastodonte/core/profile/follow/Follow.kt).