### PR TITLE
Fix crash on Mastodon authorization

### DIFF
--- a/app/src/main/java/com/jeanbarrossilva/mastodonte/app/module/core/CoreModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/mastodonte/app/module/core/CoreModule.kt
@@ -72,7 +72,7 @@ private inline fun <reified A1 : Authorizer, reified A2 : Authenticator> CoreMod
     noinline feedProvider: Definition<FeedProvider>,
     noinline profileProvider: Definition<ProfileProvider>,
     noinline tootProvider: Definition<TootProvider>,
-    noinline onBottomAreaAvailabilityChangeListener: Definition<OnBottomAreaAvailabilityChangeListener> // ktlint-disable max-line-length
+    noinline onBottomAreaAvailabilityChangeListener: Definition<OnBottomAreaAvailabilityChangeListener> // ktlint-disable max-line-length parameter-wrapping
 ): Module {
     return module {
         authorizer?.let { single(definition = it) binds arrayOf(Authorizer::class, A1::class) }

--- a/app/src/main/java/com/jeanbarrossilva/mastodonte/app/module/core/CoreModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/mastodonte/app/module/core/CoreModule.kt
@@ -3,6 +3,7 @@ package com.jeanbarrossilva.mastodonte.app.module.core
 import android.content.Context
 import com.jeanbarrossilva.mastodonte.core.auth.AuthenticationLock
 import com.jeanbarrossilva.mastodonte.core.auth.Authenticator
+import com.jeanbarrossilva.mastodonte.core.auth.Authorizer
 import com.jeanbarrossilva.mastodonte.core.feed.FeedProvider
 import com.jeanbarrossilva.mastodonte.core.mastodon.MastodonDatabase
 import com.jeanbarrossilva.mastodonte.core.mastodon.auth.authentication.MastodonAuthenticator
@@ -15,8 +16,10 @@ import com.jeanbarrossilva.mastodonte.core.profile.ProfileProvider
 import com.jeanbarrossilva.mastodonte.core.sharedpreferences.actor.SharedPreferencesActorProvider
 import com.jeanbarrossilva.mastodonte.core.toot.TootProvider
 import com.jeanbarrossilva.mastodonte.platform.theme.reactivity.OnBottomAreaAvailabilityChangeListener
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.definition.Definition
 import org.koin.core.module.Module
+import org.koin.dsl.binds
 import org.koin.dsl.module
 import org.koin.java.KoinJavaComponent
 
@@ -26,12 +29,12 @@ internal fun MainCoreModule(
 ): Module {
     val context = KoinJavaComponent.get<Context>(Context::class.java)
     val actorProvider = SharedPreferencesActorProvider(context)
-    val authorizer = MastodonAuthorizer(context)
     val tootPaginateSource = MastodonFeedProvider.PaginateSource()
     val database = MastodonDatabase.getInstance(context)
     val profileStore = MastodonProfileStore(tootPaginateSource, database.profileEntityDao)
     return CoreModule(
-        { MastodonAuthenticator(context, authorizer, actorProvider) },
+        { MastodonAuthorizer(androidContext()) },
+        { MastodonAuthenticator(context, authorizer = get(), actorProvider) },
         { AuthenticationLock(authenticator = get(), actorProvider) },
         { MastodonFeedProvider(actorProvider, tootPaginateSource) },
         { MastodonProfileProvider(profileStore) },
@@ -50,8 +53,31 @@ internal fun CoreModule(
     tootProvider: Definition<TootProvider>,
     onBottomAreaAvailabilityChangeListener: Definition<OnBottomAreaAvailabilityChangeListener>
 ): Module {
+    return CoreModule<Authorizer, Authenticator>(
+        authorizer = null,
+        authenticator,
+        authenticationLock,
+        feedProvider,
+        profileProvider,
+        tootProvider,
+        onBottomAreaAvailabilityChangeListener
+    )
+}
+
+@Suppress("FunctionName")
+private inline fun <reified A1 : Authorizer, reified A2 : Authenticator> CoreModule(
+    noinline authorizer: Definition<A1>?,
+    noinline authenticator: Definition<A2>,
+    noinline authenticationLock: Definition<AuthenticationLock>,
+    noinline feedProvider: Definition<FeedProvider>,
+    noinline profileProvider: Definition<ProfileProvider>,
+    noinline tootProvider: Definition<TootProvider>,
+    noinline onBottomAreaAvailabilityChangeListener:
+        Definition<OnBottomAreaAvailabilityChangeListener>
+): Module {
     return module {
-        single(definition = authenticator)
+        authorizer?.let { single(definition = it) binds arrayOf(Authorizer::class, A1::class) }
+        single(definition = authenticator) binds arrayOf(Authenticator::class, A2::class)
         single(definition = authenticationLock)
         single(definition = feedProvider)
         single(definition = profileProvider)

--- a/app/src/main/java/com/jeanbarrossilva/mastodonte/app/module/core/CoreModule.kt
+++ b/app/src/main/java/com/jeanbarrossilva/mastodonte/app/module/core/CoreModule.kt
@@ -72,8 +72,7 @@ private inline fun <reified A1 : Authorizer, reified A2 : Authenticator> CoreMod
     noinline feedProvider: Definition<FeedProvider>,
     noinline profileProvider: Definition<ProfileProvider>,
     noinline tootProvider: Definition<TootProvider>,
-    noinline onBottomAreaAvailabilityChangeListener:
-        Definition<OnBottomAreaAvailabilityChangeListener>
+    noinline onBottomAreaAvailabilityChangeListener: Definition<OnBottomAreaAvailabilityChangeListener> // ktlint-disable max-line-length
 ): Module {
     return module {
         authorizer?.let { single(definition = it) binds arrayOf(Authorizer::class, A1::class) }


### PR DESCRIPTION
[`MastodonAuthorizer`](https://github.com/jeanbarrossilva/Mastodonte/blob/42cd330d519bbc145fdc8343bb3b33ba0fadd11e/core/mastodon/src/main/java/com/jeanbarrossilva/mastodonte/core/mastodon/auth/authorization/MastodonAuthorizer.kt) (and also [`MastodonAuthenticator`](https://github.com/jeanbarrossilva/Mastodonte/blob/42cd330d519bbc145fdc8343bb3b33ba0fadd11e/core/mastodon/src/main/java/com/jeanbarrossilva/mastodonte/core/mastodon/auth/authentication/MastodonAuthenticator.kt)) wasn't explicitly injected as such.