### PR TITLE
Use samples instead of fetching from Mastodon API while in demo

### DIFF
--- a/app/src/demo/AndroidManifest.xml
+++ b/app/src/demo/AndroidManifest.xml
@@ -3,6 +3,13 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <application tools:ignore="MissingApplicationIcon">
-        <activity android:name=".demo.DemoMastodonteActivity" />
+        <activity
+            android:name=".demo.DemoMastodonteActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>


### PR DESCRIPTION
Demo version of the app was using the core Mastodon implementation ([`:core:mastodon`](https://github.com/jeanbarrossilva/Mastodonte/tree/829ac42f527f021a37318903311fdfee8c988306/core/mastodon)) instead of the sample one ([`:core:sample`](https://github.com/jeanbarrossilva/Mastodonte/tree/829ac42f527f021a37318903311fdfee8c988306/core/sample)).