### PR TITLE
Use `Follow.Companion#of` at `MastodonProfileEntity`

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/mastodonte/core/mastodon/feed/profile/cache/persistence/entity/MastodonProfileEntity.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/mastodonte/core/mastodon/feed/profile/cache/persistence/entity/MastodonProfileEntity.kt
@@ -58,14 +58,7 @@ data class MastodonProfileEntity internal constructor(
         MastodonFollowableProfile<Follow> {
         val account = Account.of(account)
         val avatarURL = URL(avatarURL)
-        val follow = when (follow) {
-            Follow.Public.unfollowed().toString() -> Follow.Public.unfollowed()
-            Follow.Public.following().toString() -> Follow.Public.following()
-            Follow.Private.unfollowed().toString() -> Follow.Private.unfollowed()
-            Follow.Private.requested().toString() -> Follow.Private.requested()
-            Follow.Private.following().toString() -> Follow.Private.following()
-            else -> throw IllegalStateException("No Follow matches \"$follow\".")
-        }
+        val follow = Follow.of(checkNotNull(follow))
         val url = URL(url)
         return MastodonFollowableProfile(
             tootPaginateSource,


### PR DESCRIPTION
Uses [`Follow.Companion#of`](https://github.com/jeanbarrossilva/Mastodonte/blob/0f12c290f5191c5b87ea6e4caa900576ecbfc3c4/core/src/main/java/com/jeanbarrossilva/mastodonte/core/feed/profile/type/followable/Follow.kt#L165) instead of parsing the [`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string) manually.