### PR TITLE
Explicit `AuthenticationLock`'s methods' un-immediacy

### DIFF
--- a/app/src/main/java/com/jeanbarrossilva/mastodonte/app/MastodonteActivity.kt
+++ b/app/src/main/java/com/jeanbarrossilva/mastodonte/app/MastodonteActivity.kt
@@ -68,7 +68,7 @@ internal open class MastodonteActivity :
 
     private fun lockByNavigatingToAuth() {
         lifecycleScope.launch {
-            get<AuthenticationLock>().lock {
+            get<AuthenticationLock>().requestLock {
                 AuthActivity.start(this@MastodonteActivity)
             }
         }

--- a/core-test/src/main/java/com/jeanbarrossilva/mastodonte/core/test/TestAuthenticationLock.kt
+++ b/core-test/src/main/java/com/jeanbarrossilva/mastodonte/core/test/TestAuthenticationLock.kt
@@ -7,7 +7,7 @@ import com.jeanbarrossilva.mastodonte.core.auth.actor.Actor
  * [AuthenticationLock] with test-specific default structures.
  *
  * @param authenticator [TestAuthenticator] through which the [Actor] will be authenticated if it
- * isn't and [unlock][AuthenticationLock.unlock] is called.
+ * isn't and [requestUnlock][AuthenticationLock.requestUnlock] is called.
  * @param actorProvider [TestActorProvider] whose provided [Actor] will be ensured to be either
  * [unauthenticated][Actor.Unauthenticated] or [authenticated][Actor.Authenticated].
  **/

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/mastodonte/core/mastodon/client/MastodonHttpClient.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/mastodonte/core/mastodon/client/MastodonHttpClient.kt
@@ -100,7 +100,7 @@ internal suspend inline fun HttpClient.authenticateAndSubmitForm(
     parameters: Parameters,
     crossinline build: HttpRequestBuilder.() -> Unit = { }
 ) {
-    authenticationLock.unlock {
+    authenticationLock.requestUnlock {
         submitForm(route, parameters) {
             bearerAuth(it.accessToken)
             build.invoke(this)
@@ -182,7 +182,7 @@ private fun ContentNegotiation.Config.setUpJsonSerialization() {
  * [Authorization][HttpHeaders.Authorization] header through the [authenticationLock].
  **/
 private suspend fun HttpMessageBuilder.authenticate() {
-    authenticationLock.unlock {
+    authenticationLock.requestUnlock {
         bearerAuth(it.accessToken)
     }
 }

--- a/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLock.kt
+++ b/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLock.kt
@@ -30,7 +30,7 @@ class AuthenticationLock(
          *
          * @param actor Provided [unauthenticated][Actor.Unauthenticated] [Actor].
          **/
-        fun onLock(actor: Actor.Unauthenticated)
+        suspend fun onLock(actor: Actor.Unauthenticated)
     }
 
     /**

--- a/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLock.kt
+++ b/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLock.kt
@@ -6,11 +6,11 @@ import com.jeanbarrossilva.mastodonte.core.auth.actor.ActorProvider
 /**
  * Ensures that an operation is only performed either by...
  *
- * - ...an [unauthenticated][Actor.Unauthenticated] [Actor], through [lock];
- * - ...an [authenticated][Actor.Authenticated] [Actor], through [unlock].
+ * - ...an [unauthenticated][Actor.Unauthenticated] [Actor], through [requestLock];
+ * - ...an [authenticated][Actor.Authenticated] [Actor], through [requestUnlock].
  *
- * @param authenticator [Authenticator] through which the [Actor] will be authenticated if it isn't
- * and [unlock] is called.
+ * @param authenticator [Authenticator] through which the [Actor] will be requested to be either
+ * [authenticated][Actor.Authenticated] or [unauthenticated][Actor.Unauthenticated].
  * @param actorProvider [ActorProvider] whose provided [Actor] will be ensured to be either
  * [unauthenticated][Actor.Unauthenticated] or [authenticated][Actor.Authenticated].
  **/
@@ -55,7 +55,7 @@ class AuthenticationLock(
      * @param listener [OnLockListener] to be notified if the [Actor] is
      * [unauthenticated][Actor.Unauthenticated].
      **/
-    suspend fun lock(listener: OnLockListener) {
+    suspend fun requestLock(listener: OnLockListener) {
         val actor = actorProvider.provide()
         if (actor is Actor.Unauthenticated) {
             listener.onLock(actor)
@@ -73,7 +73,7 @@ class AuthenticationLock(
      * @return Result of the [listener]'s [onUnlock][OnUnlockListener.onUnlock].
      * @throws FailedAuthenticationException If authentication fails.
      **/
-    suspend fun <T> unlock(listener: OnUnlockListener<T>): T {
+    suspend fun <T> requestUnlock(listener: OnUnlockListener<T>): T {
         return when (val actor = actorProvider.provide()) {
             is Actor.Unauthenticated -> authenticateAndNotify(listener)
             is Actor.Authenticated -> listener.onUnlock(actor)

--- a/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLock.kt
+++ b/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLock.kt
@@ -9,8 +9,8 @@ import com.jeanbarrossilva.mastodonte.core.auth.actor.ActorProvider
  * - ...an [unauthenticated][Actor.Unauthenticated] [Actor], through [requestLock];
  * - ...an [authenticated][Actor.Authenticated] [Actor], through [requestUnlock].
  *
- * @param authenticator [Authenticator] through which the [Actor] will be requested to be either
- * [authenticated][Actor.Authenticated] or [unauthenticated][Actor.Unauthenticated].
+ * @param authenticator [Authenticator] through which the [Actor] will be requested to be
+ * [authenticated][Actor.Authenticated].
  * @param actorProvider [ActorProvider] whose provided [Actor] will be ensured to be either
  * [unauthenticated][Actor.Unauthenticated] or [authenticated][Actor.Authenticated].
  **/

--- a/core/src/test/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLockTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLockTests.kt
@@ -13,7 +13,7 @@ internal class AuthenticationLockTests {
     fun `GIVEN an unauthenticated actor WHEN locking THEN the listener is notified`() {
         var hasListenerBeenNotified = false
         runTest {
-            TestAuthenticationLock().lock {
+            TestAuthenticationLock().requestLock {
                 hasListenerBeenNotified = true
             }
         }
@@ -27,7 +27,7 @@ internal class AuthenticationLockTests {
         var hasListenerBeenNotified = false
         runTest {
             authenticator.authenticate()
-            TestAuthenticationLock(actorProvider, authenticator).lock {
+            TestAuthenticationLock(actorProvider, authenticator).requestLock {
                 hasListenerBeenNotified = true
             }
         }
@@ -39,7 +39,7 @@ internal class AuthenticationLockTests {
         var hasBeenAuthenticated = false
         val authenticator = TestAuthenticator { hasBeenAuthenticated = true }
         runTest {
-            TestAuthenticationLock(authenticator = authenticator).unlock {
+            TestAuthenticationLock(authenticator = authenticator).requestUnlock {
             }
         }
         assertTrue(hasBeenAuthenticated)
@@ -49,7 +49,7 @@ internal class AuthenticationLockTests {
     fun `GIVEN an authenticated actor WHEN unlocking THEN the listener is notified`() {
         var hasListenerBeenNotified = false
         runTest {
-            TestAuthenticationLock().lock {
+            TestAuthenticationLock().requestLock {
                 hasListenerBeenNotified = true
             }
         }


### PR DESCRIPTION
"lock" is now [`requestLock`](https://github.com/jeanbarrossilva/Mastodonte/blob/5f29b854cf3f4bc693184f508641d01dcb47fb87/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLock.kt#L58) and "unlock" is [`requestUnlock`](https://github.com/jeanbarrossilva/Mastodonte/blob/5f29b854cf3f4bc693184f508641d01dcb47fb87/core/src/main/java/com/jeanbarrossilva/mastodonte/core/auth/AuthenticationLock.kt#L76).